### PR TITLE
Allow user certs imported into android to be accepted

### DIFF
--- a/app/src/fcm/AndroidManifest.xml
+++ b/app/src/fcm/AndroidManifest.xml
@@ -10,6 +10,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:theme="@style/Theme.UPExample">
         <uses-library android:name="org.apache.http.legacy" android:required="false" />
         <activity android:name=".MainActivity">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:usesCleartextTraffic="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:theme="@style/Theme.UPExample">
         <uses-library android:name="org.apache.http.legacy" android:required="false" />
         <activity android:name=".MainActivity">

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<network-security-config>
+    <!-- We need to allow clear traffic for those who don't have SSL setup. -->
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <!-- Trust preinstalled CAs -->
+            <certificates src="system"/>
+            <!-- Additionally trust user added CAs -->
+            <certificates src="user"/>
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
This will allow user-defined CA certificates already imported into android to be accepted by the app. The code is a clone of https://github.com/home-assistant/android/pull/194 and the reasoning behind this can be found in the equivalent issue: https://github.com/home-assistant/android/issues/48